### PR TITLE
Add extra write and quit commands

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -85,6 +85,15 @@ nmap ga <Plug>(EasyAlign)
 
 " ----------------------------------------------------
 
+" ---------- custom commands -------------------------
+
+command W w
+command Q q
+command WQ wq
+command Wq wq
+
+" ----------------------------------------------------
+
 " ---------- setup vim startup defautl ---------------
 autocmd StdinReadPre * let s:std_in=1
 autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | endif


### PR DESCRIPTION
See #1 

Adding extra commands to write and quit helps avoid fat fingering shift when trying to write and quit (in the case that you don't release shift after typing ":" fast enough)

