### PR TITLE
Add nnoremap ; :

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -61,6 +61,11 @@ nnoremap <leader>tab <c-w><s-t>
 vnoremap <leader>o o<Esc>
 nnoremap ; :
 
+" save file
+vmap <C-s> :w<CR>
+nmap <C-s> :w<CR>
+imap <C-s> <Esc>:w<CR>i
+
 " emmet
 imap <silent> <c-@> <c-y>,
 

--- a/.vimrc
+++ b/.vimrc
@@ -59,6 +59,7 @@ vnoremap H <s-^>
 nnoremap <leader>o o<Esc>
 nnoremap <leader>tab <c-w><s-t>
 vnoremap <leader>o o<Esc>
+nnoremap ; :
 
 " emmet
 imap <silent> <c-@> <c-y>,


### PR DESCRIPTION
Generally, mapping ; to : avoids the need to press the SHIFT key.

Example:

;q<CR>

will be the same as:

<SHIFT>:q<CR>